### PR TITLE
feat: 공고 검색/페이징/정렬 추가(Todo 날짜별, Enum), 이력서 수정

### DIFF
--- a/src/main/java/com/jobseek/speedjobs/controller/RecruitController.java
+++ b/src/main/java/com/jobseek/speedjobs/controller/RecruitController.java
@@ -5,6 +5,7 @@ import com.jobseek.speedjobs.domain.user.User;
 import com.jobseek.speedjobs.dto.recruit.RecruitListResponse;
 import com.jobseek.speedjobs.dto.recruit.RecruitRequest;
 import com.jobseek.speedjobs.dto.recruit.RecruitResponse;
+import com.jobseek.speedjobs.dto.recruit.RecruitSearchCondition;
 import com.jobseek.speedjobs.service.RecruitService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -58,17 +59,18 @@ public class RecruitController {
 		return ResponseEntity.created(URI.create("/api/recruit/" + recruitId)).build();
 	}
 
-	@ApiOperation(value = "공고 단건 조회", notes = "공고를 1개 조회한다.")
+	@ApiOperation(value = "공고 단건 조회", notes = "공고를 조회한다.")
 	@GetMapping("/{recruitId}")
 	public ResponseEntity<RecruitResponse> findRecruit(@PathVariable Long recruitId,
 		@LoginUser User user) {
 		return ResponseEntity.ok().body(recruitService.findById(recruitId, user));
 	}
 
-	@ApiOperation(value = "공고 페이징 조회", notes = "공고를 페이징으로 조회한다")
+	@ApiOperation(value = "공고 전체 조회", notes = "공고를 전체 조회한다")
 	@GetMapping
-	public ResponseEntity<Page<RecruitResponse>> findRecruitsByPage(Pageable pageable, @LoginUser User user) {
-		return ResponseEntity.ok().body(recruitService.findByPage(pageable, user));
+	public ResponseEntity<Page<RecruitResponse>> findAll(Pageable pageable, @LoginUser User user,
+		RecruitSearchCondition condition) {
+		return ResponseEntity.ok().body(recruitService.findAll(condition, pageable, user));
 	}
 
 	/**
@@ -86,7 +88,8 @@ public class RecruitController {
 	@ApiOperation(value = "공고 찜하기 취소", notes = "공고를 찜목록에서 삭제한다.")
 	@PreAuthorize("hasAnyRole('MEMBER', 'COMPANY')")
 	@DeleteMapping("/{recruitId}/favorite")
-	public ResponseEntity<Void> deleteRecruitFavorite(@PathVariable Long recruitId, @LoginUser User user) {
+	public ResponseEntity<Void> deleteRecruitFavorite(@PathVariable Long recruitId,
+		@LoginUser User user) {
 		recruitService.deleteRecruitFavorite(recruitId, user);
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/jobseek/speedjobs/domain/company/CompanyDetail.java
+++ b/src/main/java/com/jobseek/speedjobs/domain/company/CompanyDetail.java
@@ -28,8 +28,19 @@ public class CompanyDetail {
 
 	private String homepage;
 
+	private String address;
+
+	private Integer avgSalary; // 단위: 만원
+
+	private Double latitude; // 위도
+
+	private Double longitude; // 경도
+
+	private Double rating; // 평가점수
+
 	public static CompanyDetail from(String registrationNumber, String description,
-		String homepage) {
-		return new CompanyDetail(registrationNumber, description, homepage);
+		String homepage, String address, Integer avgSalary, Double latitude, Double longitude, Double rating) {
+		return new CompanyDetail(registrationNumber, description,
+			homepage, address, avgSalary, latitude, longitude, rating);
 	}
 }

--- a/src/main/java/com/jobseek/speedjobs/domain/post/PostQueryRepository.java
+++ b/src/main/java/com/jobseek/speedjobs/domain/post/PostQueryRepository.java
@@ -3,45 +3,38 @@ package com.jobseek.speedjobs.domain.post;
 import static com.jobseek.speedjobs.domain.post.QPost.post;
 import static com.jobseek.speedjobs.domain.tag.QTag.tag;
 import static com.jobseek.speedjobs.domain.user.QUser.user;
+import static com.jobseek.speedjobs.utils.QueryDslUtil.getAllOrderSpecifiers;
 
 import com.jobseek.speedjobs.dto.post.PostSearchCondition;
-import com.jobseek.speedjobs.utils.QueryDslUtil;
-import com.querydsl.core.QueryResults;
-import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
-@Slf4j
 @RequiredArgsConstructor
 @Repository
 public class PostQueryRepository {
 
-	private final QueryDslUtil queryDslUtil;
 	private final JPAQueryFactory queryFactory;
 
 	public Page<Post> findAll(PostSearchCondition condition, Pageable pageable) {
-		List<OrderSpecifier> orders = getAllOrderSpecifiers(pageable);
+		List<OrderSpecifier> orders = getAllOrderSpecifiers(pageable, post);
 		List<Post> content = queryFactory
 			.selectFrom(post)
 			.leftJoin(post.tags, tag)
 			.leftJoin(post.user, user)
 			.where(
-				containTagIds(condition.getTagIds()),
-				startsWithAuthorName(condition.getAuthor()),
+				containsTagIds(condition.getTagIds()),
+				containsAuthor(condition.getAuthor()),
+				containTitle(condition.getTitle()),
 				containContent(condition.getContent())
 			)
 			.offset(pageable.getOffset())
@@ -54,75 +47,27 @@ public class PostQueryRepository {
 			.leftJoin(post.tags, tag)
 			.leftJoin(post.user, user)
 			.where(
-				containTagIds(condition.getTagIds()),
-				startsWithAuthorName(condition.getAuthor()),
+				containsTagIds(condition.getTagIds()),
+				containsAuthor(condition.getAuthor()),
+				containTitle(condition.getTitle()),
 				containContent(condition.getContent())
 			);
 		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
 	}
 
-	public Page<Post> findAll2(PostSearchCondition condition, Pageable pageable) {
-		List<OrderSpecifier> orders = getAllOrderSpecifiers(pageable);
-		QueryResults<Post> results = queryFactory
-			.selectFrom(post)
-			.leftJoin(post.tags, tag)
-			.leftJoin(post.user, user)
-			.where(
-				containTagIds(condition.getTagIds()),
-				startsWithAuthorName(condition.getAuthor())
-			)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.orderBy(orders.toArray(new OrderSpecifier[0]))
-			.fetchResults();
-
-		log.info("results - {}, ", results);
-
-		List<Post> result = results.getResults();
-
-		log.info("개수 - {}", result.size());
-
-		long total = results.getTotal();
-		return new PageImpl<>(result, pageable, total);
-	}
-
-	private BooleanExpression containTagIds(List<Long> tagIds) { //1, 2, 9, 14 => X
+	private BooleanExpression containsTagIds(List<Long> tagIds) {
 		return (tagIds == null) ? null : post.tags.any().id.in(tagIds);
 	}
 
-	private BooleanExpression startsWithAuthorName(String author) {
-		return !StringUtils.hasText(author) ? null : post.user.nickname.startsWith(author);
+	private BooleanExpression containsAuthor(String author) {
+		return !StringUtils.hasText(author) ? null : post.user.nickname.contains(author);
+	}
+
+	private BooleanExpression containTitle(String title) {
+		return !StringUtils.hasText(title) ? null : post.title.contains(title);
 	}
 
 	private BooleanExpression containContent(String content) {
 		return !StringUtils.hasText(content) ? null : post.postDetail.content.contains(content);
-	}
-
-	private BooleanExpression eqTagId(Long tagId) {
-		if (tagId == 0) {
-			return null;
-		}
-		return tag.id.eq(tagId);
-	}
-
-	private BooleanExpression eqAuthorId(Long authorId) {
-		if (authorId == 0) {
-			return null;
-		}
-		return user.id.eq(authorId);
-	}
-
-	private List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable) {
-
-		List<OrderSpecifier> orders = new ArrayList<>();
-
-		for (Sort.Order order : pageable.getSort()) {
-			Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
-			OrderSpecifier<?> orderSpecifier = QueryDslUtil
-				.getSortedColumn(direction, post, order.getProperty());
-			orders.add(orderSpecifier);
-		}
-
-		return orders;
 	}
 }

--- a/src/main/java/com/jobseek/speedjobs/domain/recruit/RecruitQueryRepository.java
+++ b/src/main/java/com/jobseek/speedjobs/domain/recruit/RecruitQueryRepository.java
@@ -1,0 +1,111 @@
+package com.jobseek.speedjobs.domain.recruit;
+
+import static com.jobseek.speedjobs.domain.company.QCompany.*;
+import static com.jobseek.speedjobs.domain.post.QPost.post;
+import static com.jobseek.speedjobs.domain.recruit.QRecruit.*;
+import static com.jobseek.speedjobs.domain.tag.QTag.*;
+import static com.jobseek.speedjobs.utils.QueryDslUtil.getAllOrderSpecifiers;
+
+import com.jobseek.speedjobs.domain.company.QCompany;
+import com.jobseek.speedjobs.domain.tag.QTag;
+import com.jobseek.speedjobs.dto.recruit.RecruitSearchCondition;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class RecruitQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public Page<Recruit> findAll(RecruitSearchCondition condition, Pageable pageable) {
+		List<OrderSpecifier> orders = getAllOrderSpecifiers(pageable, recruit);
+		List<Recruit> content = queryFactory
+			.selectFrom(recruit)
+			.leftJoin(recruit.tags, tag)
+			.leftJoin(recruit.company, company)
+			.where(
+				containsTagIds(condition.getTagIds()),
+				containsTitle(condition.getTitle()),
+				containsContent(condition.getContent()),
+				containsCompanyName(condition.getCompanyName()),
+				containsAddress(condition.getAddress()),
+				goeAvgSalary(condition.getAvgSalary()),
+				goeRating(condition.getRating())
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(orders.toArray(new OrderSpecifier[0]))
+			.fetch().stream().distinct().collect(Collectors.toList());
+
+		JPAQuery<Recruit> countQuery = queryFactory
+			.selectFrom(recruit)
+			.leftJoin(recruit.tags, tag)
+			.leftJoin(recruit.company, company)
+			.where(
+				containsTagIds(condition.getTagIds()),
+				containsTitle(condition.getTitle()),
+				containsContent(condition.getContent()),
+				containsCompanyName(condition.getCompanyName()),
+				containsAddress(condition.getAddress()),
+				goeAvgSalary(condition.getAvgSalary()),
+				goeRating(condition.getRating())
+			);
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+	}
+
+	private BooleanExpression containsTagIds(List<Long> tagIds) {
+		return (tagIds == null) ? null : recruit.tags.any().id.in(tagIds);
+	}
+
+	private BooleanExpression containsTitle(String title) {
+		return !StringUtils.hasText(title) ? null : recruit.title.contains(title);
+	}
+
+	private BooleanExpression containsContent(String content) {
+		return !StringUtils.hasText(content) ? null
+			: recruit.recruitDetail.content.contains(content);
+	}
+
+	private BooleanExpression containsCompanyName(String companyName) {
+		return !StringUtils.hasText(companyName) ? null
+			: recruit.company.companyName.contains(companyName);
+	}
+
+	private BooleanExpression containsAddress(String address) {
+		return !StringUtils.hasText(address) ? null
+			: recruit.company.companyDetail.address.contains(address);
+	}
+
+	private BooleanExpression goeAvgSalary(Integer avgSalary) {
+		return avgSalary == null ? null : recruit.company.companyDetail.avgSalary.goe(avgSalary);
+	}
+
+	private BooleanExpression goeRating(Double rating) {
+		return rating == null ? null : recruit.company.companyDetail.rating.goe(rating);
+	}
+
+//	private BooleanExpression afterOpen(LocalDateTime open) {
+//		return open == null ? null : recruit.openDate.after(open);
+//	}
+
+//	private BooleanExpression eqExperience(Experience experience) {
+//		return ObjectUtils.isEmpty(experience) ? recruit.recruitDetail.experience.eq(experience) : null;
+//	}
+
+
+}

--- a/src/main/java/com/jobseek/speedjobs/domain/resume/Resume.java
+++ b/src/main/java/com/jobseek/speedjobs/domain/resume/Resume.java
@@ -11,6 +11,7 @@ import com.jobseek.speedjobs.domain.member.Member;
 import com.jobseek.speedjobs.domain.resume.details.Career;
 import com.jobseek.speedjobs.domain.resume.details.Certificate;
 import com.jobseek.speedjobs.domain.resume.details.Scholar;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CollectionTable;
@@ -35,7 +36,6 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-@Builder
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PRIVATE)
 @Table(name = "resumes")
@@ -50,6 +50,16 @@ public class Resume extends BaseTimeEntity {
 	private Open open;
 
 	private String coverLetter;
+
+	private String title;
+
+	private String name;
+
+	private String gender;
+
+	private String contact;
+
+	private LocalDate birth;
 
 	private String address;
 
@@ -78,35 +88,28 @@ public class Resume extends BaseTimeEntity {
 	@OneToMany(mappedBy = "resume", cascade = ALL, orphanRemoval = true)
 	private List<Apply> applies = new ArrayList<>();
 
-	public Resume(Open open, String coverLetter, String address, String blogUrl, String githubUrl,
+	@Builder
+	public Resume(Open open, String coverLetter, String title, String name, String gender,
+		String contact, LocalDate birth, String address, String blogUrl, String githubUrl,
 		String resumeImage) {
 		this.open = open;
 		this.coverLetter = coverLetter;
+		this.title = title;
+		this.name = name;
+		this.gender = gender;
+		this.contact = contact;
+		this.birth = birth;
 		this.address = address;
 		this.blogUrl = blogUrl;
 		this.githubUrl = githubUrl;
 		this.resumeImage = resumeImage;
 	}
 
-	public Resume(Open open, String coverLetter, String address, String blogUrl, String githubUrl,
-		String resumeImage, List<Certificate> certificates, List<Scholar> scholars,
-		List<Career> careers) {
-		this.open = open;
-		this.coverLetter = coverLetter;
-		this.address = address;
-		this.blogUrl = blogUrl;
-		this.githubUrl = githubUrl;
-		this.resumeImage = resumeImage;
-		this.certificateList = certificates;
-		this.scholarList = scholars;
-		this.careerList = careers;
-	}
-
-	public static Resume createResume(Open open, String coverLetter, String address, String blogUrl,
-		String githubUrl, String resumeImage, List<Certificate> certificates,
-		List<Scholar> scholars, List<Career> careers) {
-		return new Resume(open, coverLetter, address, blogUrl, githubUrl, resumeImage, certificates,
-			scholars, careers);
+	public static Resume createResume(Open open, String coverLetter, String title, String name, String gender,
+		String contact, LocalDate birth, String address, String blogUrl, String githubUrl,
+		String resumeImage) {
+		return new Resume(open, coverLetter, title, name, gender, contact, birth, address, blogUrl,
+			githubUrl, resumeImage);
 	}
 
 	//연관관계 편의 메서드
@@ -115,16 +118,17 @@ public class Resume extends BaseTimeEntity {
 		member.getResumeList().add(this);
 	}
 
-	public void addCareer(Career career) {
-		careerList.add(career);
+	public void addMoreInfo(List<Career> careers, List<Scholar> scholars, List<Certificate> certificates) {
+		this.careerList.addAll(careers);
+		this.scholarList.addAll(scholars);
+		this.certificateList.addAll(certificates);
 	}
 
-	public void addScholar(Scholar scholar) {
-		scholarList.add(scholar);
-	}
-
-	public void addCertificate(Certificate certificate) {
-		certificateList.add(certificate);
+	public void updateInfo(List<Career> careers, List<Scholar> scholars, List<Certificate> certificates) {
+		this.careerList.clear();
+		this.scholarList.clear();
+		this.certificateList.clear();
+		addMoreInfo(careers,scholars,certificates);
 	}
 
 	public void update(Resume resume) {

--- a/src/main/java/com/jobseek/speedjobs/domain/tag/Tag.java
+++ b/src/main/java/com/jobseek/speedjobs/domain/tag/Tag.java
@@ -24,7 +24,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@ToString
 @AllArgsConstructor(access = PRIVATE)
 @NoArgsConstructor(access = PROTECTED)
 @Entity

--- a/src/main/java/com/jobseek/speedjobs/dto/post/PostListResponse.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/post/PostListResponse.java
@@ -31,21 +31,6 @@ public class PostListResponse {
 	private LocalDateTime modifiedDate;
 	private Map<Type, List<TagMap>> tags;
 
-	public PostListResponse(Post post, User user) {
-		User author = post.getUser();
-		this.id = post.getId();
-		this.authorId = author.getId();
-		this.title = post.getTitle();
-		this.author = author.getNickname();
-		this.commentCount = post.getCommentCount();
-		this.viewCount = post.getViewCount();
-		this.favoriteCount = post.getFavoriteCount();
-		this.favorite = post.favoriteOf(user);
-		this.createdDate = post.getCreatedDate();
-		this.modifiedDate = post.getModifiedDate();
-		this.tags = TagMap.toMap(post.getTags());
-	}
-
 	public static PostListResponse of(Post post, User user) {
 		User author = post.getUser();
 		return PostListResponse.builder()

--- a/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitRequest.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitRequest.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,6 +43,21 @@ public class RecruitRequest {
 	private String content;
 
 	private List<Long> tagIds;
+
+	@Builder
+	public RecruitRequest(String title, LocalDateTime openDate, LocalDateTime closeDate,
+		Status status, String thumbnail, Experience experience,
+		Position position, String content, List<Long> tagIds) {
+		this.title = title;
+		this.openDate = openDate;
+		this.closeDate = closeDate;
+		this.status = status;
+		this.thumbnail = thumbnail;
+		this.experience = experience;
+		this.position = position;
+		this.content = content;
+		this.tagIds = tagIds;
+	}
 
 	public Recruit toEntity() {
 		return Recruit

--- a/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitResponse.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitResponse.java
@@ -43,6 +43,11 @@ public class RecruitResponse {
 	private int scale;
 	private String description;
 	private String homepage;
+	private String address;
+	private Integer avgSalary; // 단위: 만원
+	private Double latitude; // 위도
+	private Double longitude; // 경도
+	private Double rating; // 평가점수
 
 	public static RecruitResponse of(Recruit recruit, User user) {
 		Company company = recruit.getCompany();
@@ -66,6 +71,11 @@ public class RecruitResponse {
 			.scale(company.getScale())
 			.description(company.getCompanyDetail().getDescription())
 			.homepage(company.getCompanyDetail().getHomepage())
+			.address(company.getCompanyDetail().getAddress())
+			.avgSalary(company.getCompanyDetail().getAvgSalary())
+			.latitude(company.getCompanyDetail().getLatitude())
+			.longitude(company.getCompanyDetail().getLongitude())
+			.rating(company.getCompanyDetail().getRating())
 			.build();
 	}
 }

--- a/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitSearchCondition.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitSearchCondition.java
@@ -1,0 +1,39 @@
+package com.jobseek.speedjobs.dto.recruit;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.jobseek.speedjobs.domain.recruit.Experience;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Data
+public class RecruitSearchCondition {
+
+	private List<Long> tagIds;
+
+	private String title;
+
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	private Experience experience;
+
+	private String companyName;
+
+	private String address;
+
+	private Integer avgSalary;
+
+	private Double rating;
+
+	@JsonFormat(pattern = "yyyy-MM-dd kk:mm:ss", timezone = "Asia/Seoul")
+//	@DateTimeFormat(pattern = "yyyy-MM-dd kk:mm:ss")
+	private LocalDateTime open;
+
+	@JsonFormat(pattern = "yyyy-MM-dd kk:mm:ss", timezone = "Asia/Seoul")
+	private LocalDateTime close;
+
+}

--- a/src/main/java/com/jobseek/speedjobs/dto/resume/ResumeRequest.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/resume/ResumeRequest.java
@@ -7,6 +7,7 @@ import com.jobseek.speedjobs.domain.resume.Resume;
 import com.jobseek.speedjobs.domain.resume.details.Career;
 import com.jobseek.speedjobs.domain.resume.details.Certificate;
 import com.jobseek.speedjobs.domain.resume.details.Scholar;
+import java.time.LocalDate;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -23,11 +24,21 @@ public class ResumeRequest {
 	@NotBlank
 	private String coverLetter;
 
+	private String title;
+
+	private String name;
+
+	private String gender;
+
+	private String contact;
+
+	private LocalDate birth;
+
 	private String address;
 
-	private String blogUrl;
-
 	private String githubUrl;
+
+	private String blogUrl;
 
 	private String resumeImage;
 
@@ -37,16 +48,22 @@ public class ResumeRequest {
 
 	private List<Certificate> certificateList;
 
-	public ResumeRequest(Open open, String coverLetter, String address, String blogUrl,
-		String githubUrl, String resumeImage,
+	public ResumeRequest(Open open, String coverLetter, String title, String name, String gender,
+		String contact, LocalDate birth, String address, String githubUrl, String blogUrl,
+		String resumeImage,
 		List<Career> careerList,
 		List<Scholar> scholarList,
 		List<Certificate> certificateList) {
 		this.open = open;
 		this.coverLetter = coverLetter;
+		this.title = title;
+		this.name = name;
+		this.gender = gender;
+		this.contact = contact;
+		this.birth = birth;
 		this.address = address;
-		this.blogUrl = blogUrl;
 		this.githubUrl = githubUrl;
+		this.blogUrl = blogUrl;
 		this.resumeImage = resumeImage;
 		this.careerList = careerList;
 		this.scholarList = scholarList;
@@ -54,7 +71,8 @@ public class ResumeRequest {
 	}
 
 	public Resume toEntity() {
-		return Resume.createResume(open, coverLetter, address, blogUrl, githubUrl, resumeImage,
-			certificateList, scholarList, careerList);
+		return Resume
+			.createResume(open, coverLetter, title, name, gender, contact, birth, address, blogUrl,
+				githubUrl, resumeImage);
 	}
 }

--- a/src/main/java/com/jobseek/speedjobs/dto/resume/ResumeResponse.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/resume/ResumeResponse.java
@@ -5,6 +5,7 @@ import com.jobseek.speedjobs.domain.resume.Resume;
 import com.jobseek.speedjobs.domain.resume.details.Career;
 import com.jobseek.speedjobs.domain.resume.details.Certificate;
 import com.jobseek.speedjobs.domain.resume.details.Scholar;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,11 @@ public class ResumeResponse {
 	private Long id;
 	private Open open;
 	private String coverLetter;
+	private String title;
+	private String name;
+	private String gender;
+	private String contact;
+	private LocalDate birth;
 	private String address;
 	private String blogUrl;
 	private String githubUrl;
@@ -29,6 +35,11 @@ public class ResumeResponse {
 		this.id = resume.getId();
 		this.open = resume.getOpen();
 		this.coverLetter = resume.getCoverLetter();
+		this.title = resume.getTitle();
+		this.name = resume.getName();
+		this.gender = resume.getGender();
+		this.contact = resume.getContact();
+		this.birth = resume.getBirth();
 		this.address = resume.getAddress();
 		this.blogUrl = resume.getBlogUrl();
 		this.githubUrl = resume.getGithubUrl();
@@ -39,7 +50,8 @@ public class ResumeResponse {
 	}
 
 	@Builder
-	public ResumeResponse(Long id, Open open, String coverLetter, String address,
+	public ResumeResponse(Long id, Open open, String coverLetter, String title,
+		String name, String gender, String contact, LocalDate birth, String address,
 		String blogUrl, String githubUrl, String resumeImage,
 		List<Certificate> certificateList,
 		List<Scholar> scholarList,
@@ -47,6 +59,11 @@ public class ResumeResponse {
 		this.id = id;
 		this.open = open;
 		this.coverLetter = coverLetter;
+		this.title = title;
+		this.name = name;
+		this.gender = gender;
+		this.contact = contact;
+		this.birth = birth;
 		this.address = address;
 		this.blogUrl = blogUrl;
 		this.githubUrl = githubUrl;
@@ -61,6 +78,11 @@ public class ResumeResponse {
 			.id(resume.getId())
 			.open(resume.getOpen())
 			.coverLetter(resume.getCoverLetter())
+			.title(resume.getTitle())
+			.name(resume.getName())
+			.gender(resume.getGender())
+			.contact(resume.getContact())
+			.birth(resume.getBirth())
 			.address(resume.getAddress())
 			.blogUrl(resume.getBlogUrl())
 			.githubUrl(resume.getGithubUrl())

--- a/src/main/java/com/jobseek/speedjobs/dto/user/UserSaveRequest.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/user/UserSaveRequest.java
@@ -61,7 +61,8 @@ public class UserSaveRequest {
 			.role(role)
 			.contact(contact)
 			.companyName(companyName)
-			.companyDetail(CompanyDetail.from(registrationNumber, null, homepage))
+			.companyDetail(CompanyDetail.from(registrationNumber, null, homepage,
+				null, null, null, null, null))
 			.build();
 	}
 

--- a/src/main/java/com/jobseek/speedjobs/dto/user/company/CompanyUpdateRequest.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/user/company/CompanyUpdateRequest.java
@@ -28,8 +28,14 @@ public class CompanyUpdateRequest {
 	private String registrationNumber;
 	private String description;
 	private String homepage;
+	private String address;
+	private Integer avgSalary; // 단위: 만원
+	private Double latitude; // 위도
+	private Double longitude; // 경도
+	private Double rating; // 평가점수
 
 	public CompanyDetail toCompanyDetail() {
-		return CompanyDetail.from(registrationNumber, description, homepage);
+		return CompanyDetail.from(registrationNumber, description, homepage, address, avgSalary,
+			latitude, longitude, rating);
 	}
 }

--- a/src/main/java/com/jobseek/speedjobs/service/PostService.java
+++ b/src/main/java/com/jobseek/speedjobs/service/PostService.java
@@ -112,6 +112,6 @@ public class PostService {
 
 	public Page<PostListResponse> findAll(PostSearchCondition condition, Pageable pageable, User user) {
 		return postQueryRepository.findAll(condition, pageable)
-			.map(post -> new PostListResponse(post, user));
+			.map(post -> PostListResponse.of(post, user));
 	}
 }

--- a/src/main/java/com/jobseek/speedjobs/service/RecruitService.java
+++ b/src/main/java/com/jobseek/speedjobs/service/RecruitService.java
@@ -6,6 +6,7 @@ import com.jobseek.speedjobs.common.exception.UnauthorizedException;
 import com.jobseek.speedjobs.domain.company.Company;
 import com.jobseek.speedjobs.domain.company.CompanyRepository;
 import com.jobseek.speedjobs.domain.recruit.Recruit;
+import com.jobseek.speedjobs.domain.recruit.RecruitQueryRepository;
 import com.jobseek.speedjobs.domain.recruit.RecruitRepository;
 import com.jobseek.speedjobs.domain.tag.Tag;
 import com.jobseek.speedjobs.domain.tag.TagRepository;
@@ -13,6 +14,7 @@ import com.jobseek.speedjobs.domain.user.User;
 import com.jobseek.speedjobs.dto.recruit.RecruitListResponse;
 import com.jobseek.speedjobs.dto.recruit.RecruitRequest;
 import com.jobseek.speedjobs.dto.recruit.RecruitResponse;
+import com.jobseek.speedjobs.dto.recruit.RecruitSearchCondition;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,7 @@ public class RecruitService {
 	private final RecruitRepository recruitRepository;
 	private final CompanyRepository companyRepository;
 	private final TagRepository tagRepository;
+	private final RecruitQueryRepository recruitQueryRepository;
 
 	@Transactional
 	public Long save(RecruitRequest recruitRequest, User user) {
@@ -40,6 +43,7 @@ public class RecruitService {
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 기업회원입니다."));
 		recruit.setCompany(company);
 		List<Tag> tags = findTagsById(recruitRequest.getTagIds());
+		recruit.addTags(tags);
 		return recruitRepository.save(recruit).getId();
 	}
 
@@ -75,6 +79,11 @@ public class RecruitService {
 		return new PageImpl<>(page.stream()
 			.map(recruit -> RecruitResponse.of(recruit, user))
 			.collect(Collectors.toList()), pageable, page.getTotalElements());
+	}
+
+	public Page<RecruitResponse> findAll(RecruitSearchCondition condition, Pageable pageable, User user) {
+		return recruitQueryRepository.findAll(condition, pageable)
+			.map(recruit -> RecruitResponse.of(recruit, user));
 	}
 
 	/**

--- a/src/main/java/com/jobseek/speedjobs/service/ResumeService.java
+++ b/src/main/java/com/jobseek/speedjobs/service/ResumeService.java
@@ -25,16 +25,16 @@ public class ResumeService {
 	private final MemberRepository memberRepository;
 
 	@Transactional
-	public Long save(User user, ResumeRequest request) {
-		Resume resume = new Resume(request.getOpen(), request.getCoverLetter(),
-			request.getAddress(), request.getBlogUrl(), request.getGithubUrl(),
-			request.getResumeImage());
+	public Long save(User user, ResumeRequest resumeRequest) {
+		Resume resume = resumeRequest.toEntity();
 		Member member = memberRepository.findById(user.getId())
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 		resume.setMember(member);
-		request.getCareerList().forEach(resume::addCareer);
-		request.getScholarList().forEach(resume::addScholar);
-		request.getCertificateList().forEach(resume::addCertificate);
+		resume.addMoreInfo(
+			resumeRequest.getCareerList(),
+			resumeRequest.getScholarList(),
+			resumeRequest.getCertificateList()
+		);
 		return resumeRepository.save(resume).getId();
 	}
 
@@ -46,6 +46,11 @@ public class ResumeService {
 			throw new UnauthorizedException("권한이 없습니다.");
 		}
 		resume.update(resumeRequest.toEntity());
+		resume.updateInfo(
+			resumeRequest.getCareerList(),
+			resumeRequest.getScholarList(),
+			resumeRequest.getCertificateList()
+			);
 	}
 
 	@Transactional

--- a/src/main/java/com/jobseek/speedjobs/utils/QueryDslUtil.java
+++ b/src/main/java/com/jobseek/speedjobs/utils/QueryDslUtil.java
@@ -1,9 +1,15 @@
 package com.jobseek.speedjobs.utils;
 
+import static com.jobseek.speedjobs.domain.post.QPost.post;
+
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.Expressions;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,5 +18,19 @@ public class QueryDslUtil {
 	public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName) {
 		Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
 		return new OrderSpecifier(order, fieldPath);
+	}
+
+	public static List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable, Path<?> parent) {
+
+		List<OrderSpecifier> orders = new ArrayList<>();
+
+		for (Sort.Order order : pageable.getSort()) {
+			Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+			OrderSpecifier<?> orderSpecifier = QueryDslUtil
+				.getSortedColumn(direction, parent, order.getProperty());
+			orders.add(orderSpecifier);
+		}
+
+		return orders;
 	}
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -32,6 +32,8 @@ values  (1, '2021-02-06 17:23:02', null, '010-1342-3433', 'member@member.com', '
 (28, '2021-04-02 17:47:34', '2021-04-11 17:49:03', '010-4990-9073', 'company28@company.com', 'KT', 'KT', '$2a$10$Fl3r4xqxC51vSgTbO30r8OWtuAaT7slbPeQfwBI/0TqtGu6KMRYoq', null, 'ROLE_COMPANY'),
 (29, '2021-02-28 17:47:38', null, '010-7531-6008', 'company29@company.com', 'NC SOFT', 'NC SOFT', '$2a$10$Fl3r4xqxC51vSgTbO30r8OWtuAaT7slbPeQfwBI/0TqtGu6KMRYoq', null, 'ROLE_COMPANY'),
 (30, '2021-01-26 17:47:42', '2021-03-02 17:49:07', '010-6919-8734', 'company30@company.com', 'NHN', 'NHN', '$2a$10$Fl3r4xqxC51vSgTbO30r8OWtuAaT7slbPeQfwBI/0TqtGu6KMRYoq', null, 'ROLE_COMPANY');
+# (31, '2021-01-26 17:47:42', '2021-03-02 17:49:07', '010-3134-8734', 'company31@company.com', 'KB Bank', 'KB Bank', '$2a$10$Fl3r4xqxC51vSgTbO30r8OWtuAaT7slbPeQfwBI/0TqtGu6KMRYoq', null, 'ROLE_COMPANY');
+# (32, '2021-01-26 17:47:42', '2021-03-02 17:49:07', '010-7373-8734', 'company32@company.com', 'Hana Bank', 'Hana Bank', '$2a$10$Fl3r4xqxC51vSgTbO30r8OWtuAaT7slbPeQfwBI/0TqtGu6KMRYoq', null, 'ROLE_COMPANY');
 insert into members (bio, birth, gender, oauth_id, provider, user_id)
 values  ('안녕하세요. 반갑습니다', '1992-05-30', 'M', null, 'LOCAL', 1),
 ('안녕하세요. 짱우진입니다', '1994-02-18', 'M', null, 'LOCAL', 2),
@@ -65,8 +67,12 @@ values  ('잡식컴퍼니입니다.', null, '123-45-67890', '(주)잡식', 'http
 ('KT입니다', null, '123-45-67906', 'KT', null, 29, 28),
 ('NC 소프트입니다', null, '123-45-67907', 'NC SOFT', null, 32, 29),
 ('NHN입니다', null, '123-45-67908', 'NHN', null, 1000, 30);
--- insert into users(email, password, name, role, contact, nickname)
--- values ('company17@company.com', '$2a$10$Fl3r4xqxC51vSgTbO30r8OWtuAaT7slbPeQfwBI/0TqtGu6KMRYoq', '네이버', 'ROLE_COMPANY', '02-832-2345', '(주)네이버'); -- 16
+# insert into companies (address, avg_salary, description, homepage, latitude, longitude, rating, registration_number, company_name, logo_image, scale, user_id)
+# values ('서울시 강남구 서초1동', 4000, '국민은행입니다.', null, 30.5, 20.3, 4.0, '123-46-23213', 'KB Bank', null, 40, 31);
+# insert into companies (address, avg_salary, description, homepage, latitude, longitude, rating, registration_number, company_name, logo_image, scale, user_id)
+# values ('서울시 강남구 방배2동', 3800, '하나은행입니다.', null, 20.8, 23.3, 4.0, '123-46-23218', 'Hana Bank', null, 30, 32);
+# insert into users(email, password, name, role, contact, nickname)
+# values ('company17@company.com', '$2a$10$Fl3r4xqxC51vSgTbO30r8OWtuAaT7slbPeQfwBI/0TqtGu6KMRYoq', '네이버', 'ROLE_COMPANY', '02-832-2345', '(주)네이버'); -- 16
 
 
 -- insert into companies(user_id, company_name, homepage, registration_number, description, logo_image, scale)

--- a/src/main/resources/http/post.http
+++ b/src/main/resources/http/post.http
@@ -52,7 +52,10 @@ Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 ### 5. 게시글 페이징 조회
-GET http://{{host}}/post?content=톰캣&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/post?content=톰캣&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/post?page=0&size=3&sort=viewCount,DESC
+#GET http://{{host}}/post?title=rest&page=0&size=3&sort=id,DESC
+GET http://{{host}}/post?page=0&size=3&sort=id,DESC
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 

--- a/src/main/resources/http/recruit.http
+++ b/src/main/resources/http/recruit.http
@@ -25,7 +25,9 @@ Authorization: Bearer {{accessToken}}
   "content": "모집합니다아",
   "tagIds": [
     1,
-    3
+    2,
+    3,
+    9
   ]
 }
 
@@ -61,8 +63,18 @@ GET http://{{host}}/recruit/16
 Accept: application/json
 Authorization: Bearer {{accessToken}}
 
-### 5. 공고 페이징 조회
-GET http://{{host}}/recruit?page=0&size=3&sort=id,DESC
+### 5. 공고 전체 조회
+#GET http://{{host}}/recruit
+#GET http://{{host}}/recruit?page=0&size=3&sort=id,DESC
+#GET http://{{host}}/recruit?tagIds=1,2,3,10&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/recruit?title=엔지니어&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/recruit?experience=TWO&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/recruit?content=국내&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/recruit?companyName=삼&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/recruit?companyName=삼&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/recruit?address=강남&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/recruit?avgSalary=5000&page=0&size=3&sort=id,DESC
+#GET http://{{host}}/recruit?rating=2&page=0&size=3&sort=id,DESC
 Accept: application/json
 Authorization: Bearer {{accessToken}}
 

--- a/src/main/resources/http/resume.http
+++ b/src/main/resources/http/resume.http
@@ -16,6 +16,10 @@ Authorization: Bearer {{accessToken}}
 
 {
   "open": "NO",
+  "title": "잡스피드 이력서",
+  "name": "잡식이",
+  "gender": "M",
+  "contact": "010-1234-5678",
   "coverLetter": "소개입니당",
   "address": "서울시 강북구 번동",
   "blogUrl": "https://www.naver.com",
@@ -89,12 +93,6 @@ Authorization: Bearer {{accessToken}}
       "position": "사장",
       "inDate": "2020-01-02 00:00:00",
       "outDate": "2021-12-15 00:00:00"
-    },
-    {
-      "companyName": "스피드잡식",
-      "position": "CTO",
-      "inDate": "2020-01-05 00:00:00",
-      "outDate": "2021-11-15 00:00:00"
     }
   ],
   "scholarList": [
@@ -128,6 +126,14 @@ Authorization: Bearer {{accessToken}}
       "institute": "토익컴퍼니",
       "certDate": "2018-05-30 13:25:08",
       "score": 900,
+      "degree": null
+    },
+    {
+      "certName": "정보처리기사",
+      "certNumber": "333-32-22222",
+      "institute": "Q-net",
+      "certDate": "2020-05-30 13:25:08",
+      "score": null,
       "degree": null
     }
   ]

--- a/src/test/java/com/jobseek/speedjobs/service/PostServiceTest.java
+++ b/src/test/java/com/jobseek/speedjobs/service/PostServiceTest.java
@@ -1,31 +1,32 @@
-package com.jobseek.speedjobs.service;
-
-import static com.jobseek.speedjobs.domain.user.Provider.LOCAL;
-import static com.jobseek.speedjobs.domain.user.Role.ROLE_COMPANY;
-import static com.jobseek.speedjobs.domain.user.Role.ROLE_MEMBER;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.jobseek.speedjobs.common.exception.NotExistException;
-import com.jobseek.speedjobs.domain.company.Company;
-import com.jobseek.speedjobs.domain.company.CompanyDetail;
-import com.jobseek.speedjobs.domain.company.CompanyRepository;
-import com.jobseek.speedjobs.domain.member.Member;
-import com.jobseek.speedjobs.domain.member.MemberRepository;
-import com.jobseek.speedjobs.domain.post.Post;
-import com.jobseek.speedjobs.domain.post.PostRepository;
-import com.jobseek.speedjobs.domain.user.User;
-import com.jobseek.speedjobs.domain.user.UserRepository;
-import com.jobseek.speedjobs.dto.post.PostRequest;
-import java.util.Arrays;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
+//package com.jobseek.speedjobs.service;
+//
+//import static com.jobseek.speedjobs.domain.user.Provider.LOCAL;
+//import static com.jobseek.speedjobs.domain.user.Role.ROLE_COMPANY;
+//import static com.jobseek.speedjobs.domain.user.Role.ROLE_MEMBER;
+//import static org.assertj.core.api.Assertions.assertThat;
+//
+//import com.jobseek.speedjobs.common.exception.NotExistException;
+//import com.jobseek.speedjobs.domain.company.Company;
+//import com.jobseek.speedjobs.domain.company.CompanyDetail;
+//import com.jobseek.speedjobs.domain.company.CompanyRepository;
+//import com.jobseek.speedjobs.domain.member.Member;
+//import com.jobseek.speedjobs.domain.member.MemberRepository;
+//import com.jobseek.speedjobs.domain.post.Post;
+//import com.jobseek.speedjobs.domain.post.PostRepository;
+//import com.jobseek.speedjobs.domain.user.User;
+//import com.jobseek.speedjobs.domain.user.UserRepository;
+//import com.jobseek.speedjobs.dto.post.PostRequest;
+//import java.util.Arrays;
+//import lombok.extern.slf4j.Slf4j;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.test.annotation.Rollback;
+//import org.springframework.test.context.junit.jupiter.SpringExtension;
+//import org.springframework.transaction.annotation.Transactional;
 
 //@ExtendWith(SpringExtension.class)
 //@SpringBootTest


### PR DESCRIPTION
## What is this PR? 🔍

- 게시글 타이틀 검색이 필요했었음, 공고에 검색 기능이 필요했음, 이력서 필드가 누락 되어도 등록이 추가되어야 했다

## Changes 📝

- 게시글에 타이틀 검색 기능을 추가했다.
- 공고에 검색 기능을 추가하고 추가 필드를 5개 추가했다.
 ( Company Details -> address, avgSalary, latitude, longitude, rating)
- 공고 검색 가능: tagIds, title, content, companyName, address, avgSalary, rating
 (//TODO => enum) experience, LocalDate open, close)
- fix: 공고 등록할시 tag가 안됐던 부분 수정
- 이력서에 필드들을 추가했다
 ( 이력서이름, 작성자명, 성별, 연락처, 생일)
- 이력서 update 변경, 조회하는부분도 데이터 추가


## Screenshot 📷

- 필요하면 첨부

## References

- 참고 자료
