### PR TITLE
fix: 공고 상태 관리

### DIFF
--- a/src/main/java/com/jobseek/speedjobs/advice/RestExceptionHandler.java
+++ b/src/main/java/com/jobseek/speedjobs/advice/RestExceptionHandler.java
@@ -5,6 +5,7 @@ import com.jobseek.speedjobs.common.exception.DuplicatedException;
 import com.jobseek.speedjobs.common.exception.ForbiddenException;
 import com.jobseek.speedjobs.common.exception.NotFoundException;
 import com.jobseek.speedjobs.common.exception.UnauthorizedException;
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -67,6 +68,7 @@ public class RestExceptionHandler {
 	public ResponseEntity<ErrorResponse> Exception(Exception e) {
 		ErrorResponse response = new ErrorResponse(e.getMessage());
 		log.error("Exception - {}", e.getMessage());
+		log.error(Arrays.toString(e.getStackTrace()));
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
 	}
 }

--- a/src/main/java/com/jobseek/speedjobs/domain/recruit/Recruit.java
+++ b/src/main/java/com/jobseek/speedjobs/domain/recruit/Recruit.java
@@ -61,7 +61,7 @@ public class Recruit extends BaseTimeEntity {
 
 	private String thumbnail;
 
-	private int experience;
+	private Integer experience;
 
 	private int viewCount;
 

--- a/src/main/java/com/jobseek/speedjobs/domain/recruit/Recruit.java
+++ b/src/main/java/com/jobseek/speedjobs/domain/recruit/Recruit.java
@@ -7,6 +7,7 @@ import static javax.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
+import com.jobseek.speedjobs.common.exception.BadRequestException;
 import com.jobseek.speedjobs.common.exception.DuplicatedException;
 import com.jobseek.speedjobs.common.exception.NotFoundException;
 import com.jobseek.speedjobs.domain.BaseTimeEntity;
@@ -100,13 +101,13 @@ public class Recruit extends BaseTimeEntity {
 		this.title = recruit.getTitle();
 		this.openDate = recruit.getOpenDate();
 		this.closeDate = recruit.getCloseDate();
-		this.status = recruit.getStatus();
 		this.thumbnail = recruit.getThumbnail();
 		this.recruitDetail = recruit.getRecruitDetail();
+		setStatus();
 	}
 
-	public Recruit changeStatus() {
-		this.status = Status.END;
+	public Recruit changeStatus(Status status) {
+		this.status = status;
 		return this;
 	}
 
@@ -147,7 +148,21 @@ public class Recruit extends BaseTimeEntity {
 		return user.getRecruitFavorites().contains(this);
 	}
 
-	public boolean applied(Long userId) {
+	public boolean isApplied(Long userId) {
 		return applies.stream().anyMatch(apply -> apply.getMemberId().equals(userId));
+	}
+
+	public void setStatus() {
+		LocalDateTime now = LocalDateTime.now();
+
+		if (closeDate.getYear() == 9999) {
+			status = Status.REGULAR;
+		} else if (openDate.isAfter(now)) {
+			status = Status.STANDBY;
+		} else if (openDate.isBefore(now) && closeDate.isAfter(now)) {
+			status = Status.PROCESS;
+		} else {
+			throw new BadRequestException("공고 일자가 올바르지 않습니다.");
+		}
 	}
 }

--- a/src/main/java/com/jobseek/speedjobs/domain/recruit/RecruitRepository.java
+++ b/src/main/java/com/jobseek/speedjobs/domain/recruit/RecruitRepository.java
@@ -10,5 +10,7 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long> {
 	@Query("SELECT r FROM Recruit r ORDER BY r.id DESC")
 	List<Recruit> findAllDesc();
 
+	List<Recruit> findAllByStatusAndOpenDateAfter(Status status, LocalDateTime now);
+
 	List<Recruit> findAllByStatusAndCloseDateBefore(Status status, LocalDateTime now);
 }

--- a/src/main/java/com/jobseek/speedjobs/domain/recruit/Status.java
+++ b/src/main/java/com/jobseek/speedjobs/domain/recruit/Status.java
@@ -1,9 +1,9 @@
 package com.jobseek.speedjobs.domain.recruit;
 
 public enum Status {
+	STANDBY("채용전"),
 	PROCESS("채용중"),
-	END("마감"),
-	EARLY("조기마감"),
+	END("채용마감"),
 	REGULAR("상시채용");
 
 	private final String name;

--- a/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitListResponse.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitListResponse.java
@@ -28,7 +28,7 @@ public class RecruitListResponse {
 	private LocalDateTime closeDate;
 	private Status status;
 	private String thumbnail;
-	private int experience;
+	private Integer experience;
 	private Position position;
 	private Map<Type, List<TagMap>> tags;
 	private LocalDateTime createdDate;

--- a/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitRequest.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitRequest.java
@@ -5,7 +5,6 @@ import com.jobseek.speedjobs.domain.company.Company;
 import com.jobseek.speedjobs.domain.recruit.Position;
 import com.jobseek.speedjobs.domain.recruit.Recruit;
 import com.jobseek.speedjobs.domain.recruit.RecruitDetail;
-import com.jobseek.speedjobs.domain.recruit.Status;
 import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.constraints.Future;
@@ -32,30 +31,25 @@ public class RecruitRequest {
 	@JsonFormat(pattern = "yyyy-MM-dd kk:mm:ss", timezone = "Asia/Seoul")
 	private LocalDateTime closeDate;
 
-	@NotNull
-	private Status status;
-
 	private String thumbnail;
 
 	@NotNull
-	private Integer experience; // 경력
+	private Integer experience;
 
 	@NotNull
-	private Position position; // 고용 형태
+	private Position position;
 
 	@NotBlank
 	private String content;
 
 	private List<Long> tagIds;
 
-	// Request에서 toEntity 메서드를 이용해서 엔티티로 반환한다.
 	public Recruit toEntity(Company company) {
 		return Recruit.builder()
 			.company(company)
 			.title(title)
 			.openDate(openDate)
 			.closeDate(closeDate)
-			.status(status)
 			.thumbnail(thumbnail)
 			.experience(experience)
 			.recruitDetail(RecruitDetail.from(position, content))

--- a/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitResponse.java
+++ b/src/main/java/com/jobseek/speedjobs/dto/recruit/RecruitResponse.java
@@ -45,7 +45,7 @@ public class RecruitResponse {
 	private String description;
 	private String homepage;
 	private String address;
-	private int avgSalary;
+	private Integer avgSalary;
 	private Double latitude;
 	private Double longitude;
 

--- a/src/main/java/com/jobseek/speedjobs/service/ResumeService.java
+++ b/src/main/java/com/jobseek/speedjobs/service/ResumeService.java
@@ -88,7 +88,7 @@ public class ResumeService {
 		Recruit recruit = recruitService.findOne(recruitId);
 		Resume resume = findOne(resumeId);
 		resume.getMember().validateMe(user.getId());
-		if (recruit.applied(user.getId())) {
+		if (recruit.isApplied(user.getId())) {
 			throw new DuplicatedException("이미 지원한 공고입니다.");
 		}
 		resume.applyTo(recruit);


### PR DESCRIPTION
## What is this PR? 🔍

- 공고 상태를 입력받지 않고 서버에서 관리한다.
- 한 시간마다 공고의 openDate, closeDate를 확인하여 상태를 변경한다.
- 공고 dto 래퍼 클래스 사용(기존에 있던 데이터 때문에 추후 primitive로 변경)

## Changes 📝


## Screenshot 📷

- 필요하면 첨부

## References

- 참고 자료
