### PR TITLE
fix: 회원 정보 수정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,3 @@ jobs:
       
     - name: Build with Gradle
       run: ./gradlew build
-      
-    - name: SonarQube analysis
-      run: ./gradlew sonarqube --info -Dsonar.host.url=${{ secrets.SONAR_HOST }} -Dsonar.login=${{ secrets.SONAR_TOKEN }}

--- a/front/src/pages/profile/IndividualModify.js
+++ b/front/src/pages/profile/IndividualModify.js
@@ -72,7 +72,7 @@ export default function IndividualModify() {
         profileTemp.picture =
           'https://upload.wikimedia.org/wikipedia/commons/8/89/Portrait_Placeholder.png';
       }
-      if (profileTemp.birth !== null) {
+      if (profileTemp.birth) {
         const date = new Date(
           profileTemp.birth[0],
           profileTemp.birth[1] - 1,

--- a/front/src/sagas/profile.js
+++ b/front/src/sagas/profile.js
@@ -35,9 +35,16 @@ function* getProfile(action) {
 function updateProfileApi(action) {
   const { data, me } = action;
   const userId = me.id;
-  axios.patch(`/user/${userId}`, data).catch((err) => {
-    throw err;
-  });
+  const role = me.role;
+  if (role === 'ROLE_MEMBER') {
+    return axios.patch(`/user/member/${userId}`, data).catch((err) => {
+      throw err;
+    });
+  } else {
+    return axios.patch(`/user/company/${userId}`, data).catch((err) => {
+      throw err;
+    });
+  }
 }
 
 function* updateProfile(action) {


### PR DESCRIPTION
## What is this PR? 🔍

- 이전 PR로 회원 정보 가져오기(GET /user/{userId})가 통합됐으며 null인 컬럼은 보내지 않게 되었다.
- 이로 인해 기존 생일의 값이 undefined가 되어 에러가 발생하는 이슈 해결
- 소나큐브 외부 서버 연동에 실패(메모리 부족) -> 로컬에서만 확인하는 것으로 변경

## Changes 📝

- build.yml
